### PR TITLE
Add button to temporarily include disabled sources

### DIFF
--- a/chrome/content/mrc_compose.xul
+++ b/chrome/content/mrc_compose.xul
@@ -109,8 +109,11 @@
                 <hbox flex="1">
                     <image id="img_wait" collapsed="false"/>
                 </hbox>
-                <html:div id="msgAutocompletePanelDiv" style="display:block; min-width:100px" >
-                </html:div>
+                <vbox flex="1">
+                  <html:div id="msgAutocompletePanelDiv" style="display:block; min-width:100px" >
+                  </html:div>
+                  <button id="msgAutocompleteAddSources" hidden="true" oncommand="mrcSearchInAll()" />
+                </vbox>
                 <hbox flex="1">
                     <label id="labelTypeMore" value="" />
                 </hbox>

--- a/chrome/locale/en-US/mrc_compose.properties
+++ b/chrome/locale/en-US/mrc_compose.properties
@@ -10,5 +10,6 @@ autocomplete2=Please open MRC Compose preferences to define autocomplete.
 ab_error=Search error for '%s'
 more_info_see_console=More informations in Error console (Tools menu)
 ab_timeout=Timeout for '%s'
-type_more=type %s more caracter(s) to start searching...
+type_more=type %s more character(s) to start searching...
 no_result=No result
+more_sources=Include disabled sources

--- a/chrome/locale/fr-FR/mrc_compose.properties
+++ b/chrome/locale/fr-FR/mrc_compose.properties
@@ -12,3 +12,5 @@ more_info_see_console=Ouvrez la Console d'erreurs (menu Outils) pour plus d'info
 ab_timeout=Timeout pour '%s'
 type_more=tapez %s caractère(s) de plus pour lancer la recherche...
 no_result=Aucun résultat
+more_sources=Inclure les sources désactivées
+


### PR DESCRIPTION
With this patch, you can leave slow ldap sources
unselected in the preferences, but include them
into a search with a single click. The next search
will revert back to the selected sources.