### PR TITLE
Add fields for locale information when install

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:em="http://www.mozilla.org/2004/em-rdf#">

--- a/install.rdf
+++ b/install.rdf
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:em="http://www.mozilla.org/2004/em-rdf#">
@@ -17,6 +17,27 @@
     </em:targetApplication>
 
     <!-- Front End MetaData -->
+    <em:localized>
+      <Description>
+        <em:locale>en-US</em:locale>
+        <em:description>Provides 3 standards fields (TO, CC, BCC) with autocomplete to Thunderbird's compose pane.</em:description>
+      </Description>
+    </em:localized>
+
+    <em:localized>
+      <Description>
+        <em:locale>fr-FR</em:locale>
+        <em:description>Provides 3 standards fields (TO, CC, BCC) with autocomplete to Thunderbird's compose pane..</em:description>
+      </Description>
+    </em:localized>
+
+    <em:localized>
+      <Description>
+        <em:locale>es-ES</em:locale>
+        <em:description>Provee 3 campos estandares (Para, CC, BCC) con autocompletado al panel de redacción de Thunderbird.</em:description>
+      </Description>
+    </em:localized>
+
     <em:name>MRC Compose</em:name>
     <em:description>Provides 3 standards fields (TO, CC, BCC) with autocomplete to Thunderbird's compose pane</em:description>
     <em:creator>Michel Renon</em:creator>


### PR DESCRIPTION
Show locale description when install addon in current locales supported (need fr-FR description), also show locale information in addons tab.

Need utf-8 for show correctly.